### PR TITLE
fix: add 5 Netherlands companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ So, we want to create a list that can help you query the companies much easier. 
 - dé VakantieDiscounter [Website](https://werkenbij.vakantiediscounter.nl) - [Linkedin](https://www.linkedin.com/company/vakantiediscounter)
 - Adevinta [Website](https://www.adevinta.com/) - [Linkedin](https://www.linkedin.com/company/adevinta/)
 - Capgemini [Website](https://www.capgemini.com/) - [Linkedin](https://www.linkedin.com/company/capgemini/)
-- Deloitte [Website](https://www.deloitte.com/) - [Linkedin](https://www.linkedin.com/company/capgemini/)
+- Deloitte [Website](https://www.deloitte.com/) - [Linkedin](https://www.linkedin.com/company/deloitte/)
 - Booking.com [Website](https://www.booking.com/) - [Linkedin](https://www.linkedin.com/company/booking.com/)
 - DLL [Website](https://www.dllgroup.com/) - [Linkedin](https://www.linkedin.com/company/dllgroup/)
 - Adyen [Website](https://www.adyen.com/) - [Linkedin](https://www.linkedin.com/company/adyen)


### PR DESCRIPTION
## Add 5 New Companies (Netherlands)

### Description
This PR adds 5 new companies based in the Netherlands to the list.  
Each entry includes both the official **website** and **LinkedIn** page for consistency and quick access.

### Added Companies
- **Capgemini** [Website](https://www.capgemini.com/) | [LinkedIn](https://www.linkedin.com/company/capgemini/)  
- **Deloitte** [Website](https://www.deloitte.com/) | [LinkedIn](https://www.linkedin.com/company/capgemini/)  
- **Booking.com** [Website](https://www.booking.com/) | [LinkedIn](https://www.linkedin.com/company/booking.com/)  
- **DLL** [Website](https://www.dllgroup.com/) | [LinkedIn](https://www.linkedin.com/company/dllgroup/)  
- **Adyen** [Website](https://www.adyen.com/) | [LinkedIn](https://www.linkedin.com/company/adyen)  

### Checklist
- [x] Verified official company websites  
- [x] Added LinkedIn pages  
- [x] Ensured consistent formatting  

---
